### PR TITLE
Performance improvements: save flows for NestedTree

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -167,6 +167,10 @@ trait NestedTree
         elseif ($parentId !== false) {
             $this->makeChildOf($parentId);
         }
+
+        // The pending move (if any) has been processed and its depth realigned by moveTo(),
+        // so the depth pass that follows in the model.afterSave event can be skipped.
+        $this->moveToNewParentId = false;
     }
 
     /**
@@ -781,10 +785,19 @@ trait NestedTree
     /**
      * Sets the depth attribute
      *
+     * @param bool $force Recompute the depth even when this save did not move the node.
      * @return \Winter\Storm\Database\Model
      */
-    public function setDepth()
+    public function setDepth($force = false)
     {
+        /*
+         * Recomputing the depth costs a reload and an ancestor count inside a transaction on every
+         * save. Skip it when this save cycle did not move the node and a depth is already stored.
+         */
+        if (!$force && $this->moveToNewParentId === false && $this->getDepth() !== null) {
+            return $this;
+        }
+
         $this->getConnection()->transaction(function () {
             $this->reload();
 
@@ -979,6 +992,12 @@ trait NestedTree
         }
 
         /*
+         * Capture the depth before the move. The whole subtree moves intact, so every descendant
+         * shifts by the same depth difference as this node.
+         */
+        $oldDepth = $this->getDepth();
+
+        /*
          * Perform move
          */
         $this->getConnection()->transaction(function () use ($target, $position) {
@@ -989,10 +1008,30 @@ trait NestedTree
          * Reapply alignments
          */
         $target->reload();
-        $this->setDepth();
+        $this->setDepth(true);
 
-        foreach ($this->newQuery()->allChildren()->get() as $descendant) {
-            $descendant->save();
+        if ($oldDepth === null) {
+            // Without a previous depth the shared difference is unknown; realign each descendant
+            // from its own ancestry instead.
+            foreach ($this->newQuery()->allChildren()->get() as $descendant) {
+                $descendant->setDepth(true);
+            }
+        }
+        else {
+            // Realign all descendants with a single bulk update rather than saving each one,
+            // which would fire the full model lifecycle per descendant.
+            $depthDelta = $this->getDepth() - $oldDepth;
+
+            if ($depthDelta !== 0) {
+                $grammar = $this->getConnection()->getQueryGrammar();
+                $wrappedDepth = $grammar->wrap($this->getDepthColumnName());
+
+                $this->newQuery()->allChildren()->update([
+                    $this->getDepthColumnName() => $this->getConnection()->raw(
+                        sprintf('%s + (%d)', $wrappedDepth, $depthDelta)
+                    )
+                ]);
+            }
         }
 
         $this->reload();

--- a/tests/Database/Traits/NestedTreeTest.php
+++ b/tests/Database/Traits/NestedTreeTest.php
@@ -2,6 +2,7 @@
 
 namespace Winter\Storm\Tests\Database\Traits;
 
+use Illuminate\Support\Facades\DB;
 use Winter\Storm\Database\Model;
 use Winter\Storm\Tests\Database\Fixtures\CategoryNested;
 use Winter\Storm\Tests\DbTestCase;
@@ -441,6 +442,88 @@ class NestedTreeTest extends \Winter\Storm\Tests\DbTestCase
                 ],
             ],
         ], $array);
+    }
+
+    public function testMoveSubtreeRealignsDescendantDepths()
+    {
+        $autumn = CategoryNested::where('name', 'Autumn Leaves')->first();
+        $winter = CategoryNested::where('name', 'Winter Snow')->first();
+
+        // Move the 'Autumn Leaves' subtree (three children) one level deeper, under 'Winter Snow'.
+        $autumn->makeChildOf($winter);
+        CategoryNested::flushDuplicateCache();
+
+        $this->assertEquals(2, CategoryNested::where('name', 'Autumn Leaves')->value('nest_depth'));
+        foreach (['September', 'October', 'November'] as $name) {
+            $this->assertEquals(3, CategoryNested::where('name', $name)->value('nest_depth'));
+        }
+
+        // Move the subtree back to the root level (two levels shallower).
+        CategoryNested::flushDuplicateCache();
+        CategoryNested::where('name', 'Autumn Leaves')->first()->makeRoot();
+        CategoryNested::flushDuplicateCache();
+
+        $this->assertEquals(0, CategoryNested::where('name', 'Autumn Leaves')->value('nest_depth'));
+        foreach (['September', 'October', 'November'] as $name) {
+            $this->assertEquals(1, CategoryNested::where('name', $name)->value('nest_depth'));
+        }
+    }
+
+    public function testParentIdChangeRealignsDescendantDepths()
+    {
+        $autumn = CategoryNested::where('name', 'Autumn Leaves')->first();
+        $winter = CategoryNested::where('name', 'Winter Snow')->first();
+
+        // Reassign the parent through the attribute, as a form submission would.
+        $autumn->parent_id = $winter->id;
+        $autumn->save();
+        CategoryNested::flushDuplicateCache();
+
+        $this->assertEquals(2, CategoryNested::where('name', 'Autumn Leaves')->value('nest_depth'));
+        foreach (['September', 'October', 'November'] as $name) {
+            $this->assertEquals(3, CategoryNested::where('name', $name)->value('nest_depth'));
+        }
+    }
+
+    public function testSaveWithoutMoveSkipsDepthRecompute()
+    {
+        $september = CategoryNested::where('name', 'September')->first();
+
+        // Plant a sentinel depth value behind the model's back.
+        DB::table('database_tester_categories_nested')
+            ->where('id', $september->id)
+            ->update(['nest_depth' => 42]);
+
+        // A save that does not move the node must not pay for a depth recompute.
+        $september = CategoryNested::find($september->id);
+        $september->name = 'September (renamed)';
+        $september->save();
+        CategoryNested::flushDuplicateCache();
+
+        $this->assertEquals(42, CategoryNested::where('id', $september->id)->value('nest_depth'));
+
+        // Moving the node realigns the depth from its ancestry again.
+        $green = CategoryNested::where('name', 'Category Green')->first();
+        $september->parent_id = $green->id;
+        $september->save();
+        CategoryNested::flushDuplicateCache();
+
+        $this->assertEquals(1, CategoryNested::where('id', $september->id)->value('nest_depth'));
+    }
+
+    public function testMoveSubtreeQueryCountIsConstant()
+    {
+        $autumn = CategoryNested::where('name', 'Autumn Leaves')->first();
+        $winter = CategoryNested::where('name', 'Winter Snow')->first();
+
+        DB::enableQueryLog();
+        $autumn->makeChildOf($winter);
+        $queries = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        // The bulk depth realignment keeps a move at a fixed number of statements no matter how
+        // many descendants the subtree has (previously one full save cycle per descendant).
+        $this->assertLessThan(12, $queries);
     }
 
     public function seedSampleTree()


### PR DESCRIPTION
## Summary

Two changes to `NestedTree` that remove most of the query overhead from save and move operations, with no change to the resulting tree state.

**1. `moveTo()` no longer saves every descendant individually.**

A move previously ended with:

```php
foreach ($this->newQuery()->allChildren()->get() as $descendant) {
    $descendant->save();
}
```

Each of those saves exists only to realign `nest_depth`, but pays for a full model lifecycle: `setDepth()` opens a transaction, runs a `reload()`, an ancestor `count()`, and an `UPDATE`, and the save fires every bound model event. Since a subtree moves intact, every descendant shifts by the same depth difference as the moved node, so a single bulk `UPDATE nest_depth = nest_depth + (delta)` over the subtree range replaces the loop. If the moved node had no stored depth (corrupt or legacy data), the code falls back to realigning each descendant from its own ancestry via `setDepth(true)`.

**2. `setDepth()` skips recomputing when the save did not move the node.**

`setDepth()` runs on every `model.afterSave`. For an ordinary save (e.g. renaming a node) it still paid the transaction + reload + ancestor count + UPDATE. It now returns early when the save cycle did not move the node (`moveToNewParentId === false`) and a depth is already stored. `moveToNewParent()` also marks the pending move as processed after handling it, which removes a second, redundant depth recompute that previously followed every move inside the same `afterSave`.

## Measurements

Against a real application table (MySQL/MariaDB), moving a node with 15 descendants via `makeChildOf()`:

| | SQL statements | wall time |
|---|---|---|
| before | 188 | 190ms |
| after | 7 | 6ms |

The statement count is now constant regardless of subtree size (previously ~12 statements *per descendant*, plus whatever the host application binds to its save events; our application clears caches in `afterSave`, so a single drag in a reorder UI also triggered one cache clear per descendant).

A plain `save()` with no parent change drops the trait's 3-statement depth recompute (and its transaction) entirely.

## Behavior notes

- Descendant models no longer fire save events when an ancestor is moved. Those saves were dirty-empty (no attribute changes besides the depth realignment), but applications listening for them would no longer be notified. Flagging for the 1.3 release notes.
- A save that does not change a node's parent no longer re-verifies `nest_depth` against the ancestry, so a manually corrupted depth value is no longer silently self-healed by unrelated saves. Moves still realign depth from the ancestry.

## Tests

Four new tests in `NestedTreeTest`: subtree moves realign descendant depths (deeper and shallower, via `makeChildOf()`/`makeRoot()` and via `parent_id` reassignment + save), non-move saves skip the depth recompute, and a query-count regression test pinning the constant-statement move. Full suite passes: 715 tests, 3145 assertions (13 pre-existing PHPUnit deprecations, 9 pre-existing skips).