### PR TITLE
Bind attach relation keys as strings to use the attachment_id index

### DIFF
--- a/src/Database/Relations/Concerns/AttachOneOrMany.php
+++ b/src/Database/Relations/Concerns/AttachOneOrMany.php
@@ -42,7 +42,12 @@ trait AttachOneOrMany
         if (static::$constraints) {
             $this->query->where($this->morphType, $this->morphClass);
 
-            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+            // Bind the parent key as a string to match the string `attachment_id` column. A numeric
+            // binding forces the database to coerce the column for every row, which prevents the
+            // column's index from being used.
+            $parentKey = $this->getParentKey();
+
+            $this->query->where($this->foreignKey, '=', is_null($parentKey) ? $parentKey : (string) $parentKey);
 
             $this->query->where('field', $this->getFieldName());
 
@@ -116,7 +121,19 @@ trait AttachOneOrMany
      */
     public function addEagerConstraints(array $models)
     {
-        parent::addEagerConstraints($models);
+        // Bind the parent keys as strings to match the string `attachment_id` column, rather than
+        // deferring to the parent implementation, which compares integer keys against the string
+        // column and prevents the column's index from being used. Null keys are preserved as-is
+        // so they match nothing, instead of being cast to an empty string.
+        $this->query->whereIn(
+            $this->foreignKey,
+            array_map(
+                fn ($key) => is_null($key) ? $key : (string) $key,
+                $this->getKeys($models, $this->localKey)
+            )
+        );
+
+        $this->query->where($this->morphType, $this->morphClass);
 
         $this->query->where('field', $this->fieldName);
     }

--- a/tests/Database/Relations/AttachOneTest.php
+++ b/tests/Database/Relations/AttachOneTest.php
@@ -2,6 +2,7 @@
 
 namespace Winter\Storm\Tests\Database\Relations;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Winter\Storm\Database\Attach\File;
 use Winter\Storm\Database\Model;
@@ -93,6 +94,80 @@ class AttachOneTest extends DbTestCase
 
         $this->assertNotNull($user2->displayPicture);
         $this->assertEquals('avatar.png', $user2->displayPicture->file_name);
+    }
+
+    public function testConstraintsBindParentKeyAsString()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $bindings = $user->avatar()->getBaseQuery()->getBindings();
+
+        // The attachment_id column is a string; the key must be bound as a string so the
+        // database can use the column's index instead of coercing every row to a number.
+        $this->assertContains((string) $user->id, $bindings);
+        $this->assertNotContains($user->id, $bindings);
+    }
+
+    public function testEagerConstraintsBindParentKeysAsStrings()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        $user2 = User::create(['name' => 'Joe', 'email' => 'joe@example.com']);
+        Model::reguard();
+
+        $relation = Relation::noConstraints(function () use ($user) {
+            return $user->avatar();
+        });
+        $relation->addEagerConstraints([$user, $user2]);
+
+        $bindings = $relation->getBaseQuery()->getBindings();
+
+        $this->assertContains((string) $user->id, $bindings);
+        $this->assertContains((string) $user2->id, $bindings);
+        $this->assertNotContains($user->id, $bindings);
+        $this->assertNotContains($user2->id, $bindings);
+    }
+
+    public function testEagerConstraintsPreserveNullParentKeys()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $unsavedUser = new User;
+
+        $relation = Relation::noConstraints(function () use ($user) {
+            return $user->avatar();
+        });
+        $relation->addEagerConstraints([$user, $unsavedUser]);
+
+        $bindings = $relation->getBaseQuery()->getBindings();
+
+        // A parent without a key must not be cast to an empty string, which could match
+        // orphaned rows where attachment_id = ''
+        $this->assertNotContains('', $bindings);
+        $this->assertContains((string) $user->id, $bindings);
+    }
+
+    public function testEagerLoadMatchesAttachmentsToParents()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        $user2 = User::create(['name' => 'Joe', 'email' => 'joe@example.com']);
+        Model::reguard();
+
+        $user->avatar()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+        $user2->avatar()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+
+        $results = User::with('avatar')->whereIn('id', [$user->id, $user2->id])->get();
+
+        foreach ($results as $result) {
+            $this->assertTrue($result->relationLoaded('avatar'));
+            $this->assertNotNull($result->avatar);
+            $this->assertEquals($result->id, $result->avatar->attachment_id);
+        }
     }
 
     public function testDeleteFlagDestroyRelationship()


### PR DESCRIPTION
## Problem

The `files` table stores `attachment_id` as an indexed **string** column, but `AttachOneOrMany::addConstraints()` and `addEagerConstraints()` bind the parent key(s) using their native integer type. Comparing a string column against an integer forces the database to coerce the column value for every candidate row, which makes the `attachment_id` index unusable.

On MySQL/MariaDB this is easy to demonstrate with `EXPLAIN`: with an integer binding the planner can only use the low-cardinality `attachment_type` index, so every attachment query scans **every file row of that morph type**. With a string binding it uses both indexes (`ref|filter` with rowid intersection) and examines only the matching rows. On installations with large `system_files` tables this is the difference between a handful of rows examined and tens of thousands — per attachment query, multiplied by however many `attachOne`/`attachMany` relations a page touches.

The eager path is affected the same way: for integer parent keys Laravel selects `whereIntegerInRaw()`, which inlines raw integers into the SQL.

## Fix

- `addConstraints()` casts the parent key to a string (preserving `null`, so the `= null` → `whereNull` conversion is unchanged).
- `addEagerConstraints()` builds the `whereIn` with string-cast keys instead of deferring to the parent implementation. Null keys are preserved as-is so they match nothing, rather than being cast to `''` (which could match orphaned rows). The morph type and field constraints are applied exactly as before.

`getRelationExistenceQuery()` already handles this same mismatch for `has()` queries by casting the parent column to TEXT via `DbDongle::cast`, so this brings the regular constraint paths in line with the approach already used there.

Result matching is unaffected: PHP normalizes numeric-string array keys, so the eager-load dictionary lookup behaves identically (covered by a new end-to-end test).

## Testing

Four new tests in `AttachOneTest`: string bindings on lazy constraints, string bindings on eager constraints, null-key preservation in eager constraints, and an end-to-end eager load asserting attachments still match their parents. Full test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment relationship constraint binding to use string-typed parent keys, ensuring proper index usage and column type matching.
  * Corrected eager-loading behavior for attachment relationships to preserve null parent keys and properly filter results.

* **Tests**
  * Added comprehensive test coverage for attachment relationship constraints and eager-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->