### PR TITLE
Follow symlinked directories in FileDatasource::getAvailablePaths()

### DIFF
--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Storm\Halcyon\Datasource;
 
 use Exception;
+use FilesystemIterator;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use Winter\Storm\Filesystem\Filesystem;
@@ -339,7 +340,10 @@ class FileDatasource extends Datasource
     {
         $pathsCache = [];
         $it = (is_dir($this->basePath))
-            ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->basePath))
+            ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
+                $this->basePath,
+                FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::FOLLOW_SYMLINKS
+            ))
             : [];
 
         foreach ($it as $file) {

--- a/tests/Halcyon/FileDatasourceTest.php
+++ b/tests/Halcyon/FileDatasourceTest.php
@@ -102,6 +102,16 @@ class FileDatasourceTest extends TestCase
         $this->assertSame([], $datasource->getAvailablePaths());
     }
 
+    public function testGetAvailablePathsFollowsSymlinkedDirectories()
+    {
+        $this->seedFile('shared/static-pages/index.htm', 'Index page');
+        symlink($this->basePath . '/shared/static-pages', $this->basePath . '/pages/linked');
+
+        $paths = array_keys($this->datasource->getAvailablePaths());
+
+        $this->assertContains('pages/linked/index.htm', $paths);
+    }
+
     //
     // selectOne()
     //


### PR DESCRIPTION
Fixes wintercms/winter#1533 (filed there since issues are disabled on this repo).

`FileDatasource::getAvailablePaths()` builds its `RecursiveDirectoryIterator` without `FOLLOW_SYMLINKS`, so `RecursiveDirectoryIterator::hasChildren()` treats a symlinked directory as a leaf and everything beneath it is skipped. This breaks zero-downtime deploy layouts (Forge/Envoyer-style) where a theme's `content`/`meta` directories are symlinks into a shared folder — a child theme (anything with `parent:` in `theme.yaml`) resolves through `AutoDatasource`, which feeds off this method, so it sees no static pages at all and every Pages URL 404s. Parent themes are unaffected because `select()`/`selectOne()` open the target path directly rather than walking through it, so the bug only shows up on the auto-datasource path-cache side.

Added the flag (keeping the two default flags explicit alongside it, since passing any explicit flags value overrides the constructor's defaults) and a regression test with a real symlinked directory. Left `select()`'s own iterator as-is — giving it the same flag surfaces a separate, pre-existing path-validation check (`makeDirectoryPath()`'s "must resolve within basePath" guard) that legitimately rejects reads through a symlink, so fixing that would be a different, bigger change than this issue asks for.

Ran the full `FileDatasourceTest` suite plus phpcs against the changed files.

Used AI assistance (Claude) to investigate and write this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-based data sources now discover files located within symlinked directories.

* **Tests**
  * Added coverage to verify file discovery through symlinked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->