### PR TITLE
Fire model.relation.beforeAdd/afterAdd events from AttachOneOrMany::create()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -177,7 +177,7 @@ parameters:
 
 		-
 			message: "#^Call to private method delete\\(\\) of parent class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\MorphOne\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\.$#"
-			count: 3
+			count: 2
 			path: src/Database/Relations/AttachOne.php
 
 		-

--- a/src/Database/Relations/Concerns/AttachOneOrMany.php
+++ b/src/Database/Relations/Concerns/AttachOneOrMany.php
@@ -150,22 +150,17 @@ trait AttachOneOrMany
      */
     public function create(array $attributes = [], $sessionKey = null)
     {
-        // Delete siblings for single attachments
-        if ($sessionKey === null && $this instanceof AttachOne) {
-            $this->delete();
-        }
-
         if (!array_key_exists('is_public', $attributes)) {
             $attributes = array_merge(['is_public' => $this->isPublic()], $attributes);
         }
 
         $attributes['field'] = $this->fieldName;
 
-        $model = parent::create($attributes);
+        $model = $sessionKey === null
+            ? $this->related->newInstance($attributes)
+            : parent::create($attributes);
 
-        if ($sessionKey !== null) {
-            $this->add($model, $sessionKey);
-        }
+        $this->add($model, $sessionKey);
 
         return $model;
     }

--- a/tests/Database/Relations/AttachManyTest.php
+++ b/tests/Database/Relations/AttachManyTest.php
@@ -82,4 +82,45 @@ class AttachManyTest extends DbTestCase
         $user->delete();
         $this->assertNull(File::find($photoId));
     }
+
+    public function testCreateFiresRelationEvents()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $beforeAddCalls = [];
+        $afterAddCalls = [];
+        $user->bindEvent('model.relation.beforeAdd', function ($relationName, $relatedModel) use (&$beforeAddCalls) {
+            $beforeAddCalls[] = [$relationName, $relatedModel];
+        });
+        $user->bindEvent('model.relation.afterAdd', function ($relationName, $relatedModel) use (&$afterAddCalls) {
+            $afterAddCalls[] = [$relationName, $relatedModel];
+        });
+
+        $photo = $user->photos()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+
+        $this->assertCount(1, $beforeAddCalls);
+        $this->assertSame('photos', $beforeAddCalls[0][0]);
+        $this->assertTrue($photo->is($beforeAddCalls[0][1]));
+
+        $this->assertCount(1, $afterAddCalls);
+        $this->assertSame('photos', $afterAddCalls[0][0]);
+        $this->assertTrue($photo->is($afterAddCalls[0][1]));
+    }
+
+    public function testCreateDoesNotReplaceExistingAttachments()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $first = $user->photos()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+        $second = $user->photos()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+
+        $this->assertNotNull(File::find($first->id));
+        $this->assertNotNull(File::find($second->id));
+        $user->reloadRelations();
+        $this->assertCount(2, $user->photos);
+    }
 }

--- a/tests/Database/Relations/AttachOneTest.php
+++ b/tests/Database/Relations/AttachOneTest.php
@@ -176,4 +176,46 @@ class AttachOneTest extends DbTestCase
         $user->delete();
         $this->assertNotNull(File::find($avatarId));
     }
+
+    public function testCreateFiresRelationEvents()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $beforeAddCalls = [];
+        $afterAddCalls = [];
+        $user->bindEvent('model.relation.beforeAdd', function ($relationName, $relatedModel) use (&$beforeAddCalls) {
+            $beforeAddCalls[] = [$relationName, $relatedModel];
+        });
+        $user->bindEvent('model.relation.afterAdd', function ($relationName, $relatedModel) use (&$afterAddCalls) {
+            $afterAddCalls[] = [$relationName, $relatedModel];
+        });
+
+        $avatar = $user->avatar()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+
+        $this->assertCount(1, $beforeAddCalls);
+        $this->assertSame('avatar', $beforeAddCalls[0][0]);
+        $this->assertTrue($avatar->is($beforeAddCalls[0][1]));
+
+        $this->assertCount(1, $afterAddCalls);
+        $this->assertSame('avatar', $afterAddCalls[0][0]);
+        $this->assertTrue($avatar->is($afterAddCalls[0][1]));
+    }
+
+    public function testCreateReplacesExistingSingleAttachment()
+    {
+        Model::unguard();
+        $user = User::create(['name' => 'Stevie', 'email' => 'stevie@example.com']);
+        Model::reguard();
+
+        $first = $user->avatar()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+        $firstId = $first->id;
+
+        $second = $user->avatar()->create(['data' => dirname(dirname(__DIR__)) . '/fixtures/attach/avatar.png']);
+
+        $this->assertNull(File::find($firstId));
+        $this->assertNotNull(File::find($second->id));
+        $this->assertNotSame($firstId, $second->id);
+    }
 }


### PR DESCRIPTION
## Summary

`AttachOneOrMany::create()` builds and persists the related model directly via `parent::create()`, bypassing `add()` entirely whenever no `sessionKey` is given — the normal, immediate (non-deferred-binding) path most `$model->relation()->create(...)` calls take. `add()` is what actually fires `model.relation.beforeAdd`/`model.relation.afterAdd`, and also handles deleting the existing sibling attachment for `AttachOne` — so both of those silently never ran through `create()`.

## Fix

Route `create()` through `add()` in both branches: when `sessionKey` is null, build an unsaved model via `$this->related->newInstance($attributes)` so `add()`'s own `$model->save()` is the only place the model actually gets persisted (avoids a double-save). The deferred-binding path (`sessionKey !== null`) still uses `parent::create()`, unchanged, since the model needs to exist immediately for the deferred-binding table row that follows.

The single-attachment sibling-deletion logic that used to live directly in `create()` is removed from there — `add()` already has the identical `if ($this instanceof AttachOne) { $this->delete(); }` check, so nothing is lost, just de-duplicated onto the one method both `save()` and `create()` now share.

## Testing

Added `testCreateFiresRelationEvents` to both `AttachOneTest` and `AttachManyTest` (confirmed each fires exactly once, with the correct relation name and model instance, by binding `model.relation.beforeAdd`/`afterAdd` and asserting on the callback args). Added `testCreateReplacesExistingSingleAttachment` to `AttachOneTest` and `testCreateDoesNotReplaceExistingAttachments` to `AttachManyTest` to lock in the existing single-vs-multi behavior wasn't disturbed by moving the sibling-deletion check.

Verified red-before/green-after: the new event tests fail against the pre-fix code (0 events fired) and pass after. Ran the full `tests/Database` suite (222 tests, 1018 assertions) — all pass, no regressions.

Fixes wintercms/winter#1147.

---
_Implemented with AI assistance (Claude Code); verified against a real PHP 8.2 test environment before submitting._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Creating multiple attachments through a collection relation now preserves existing attachments instead of replacing them.
  - Creating a new attachment through a single-item relation replaces the previous attachment.
  - Relation add events now fire consistently when attachments are created through relations.

- **Tests**
  - Added coverage for attachment preservation and replacement behavior.
  - Added coverage confirming relation events are dispatched with the expected relation and attachment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->